### PR TITLE
 Add "watch" option

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -11,8 +11,11 @@ module.exports = ({ configPath }) => {
   if (fs.existsSync(ngTwFile)) {
     const config = require(ngTwFile)
 
-    const tailwind = chokidar.watch([config.configJS, config.sourceCSS])
-
+    let watchedFiles = [config.configJS, config.sourceCSS];
+    if (config.watch) {
+      watchedFiles = watchedFiles.concat(config.watch);
+    }
+    const tailwind = chokidar.watch(watchedFiles);
     tailwind.on('change', (event, path) => {
       console.log('Reprocessing changes to Tailwind files')
 
@@ -29,7 +32,9 @@ module.exports = ({ configPath }) => {
       build({ configPath })
     })
 
-    printWatchedFiles(config.configJS, config.sourceCSS, ngTwFile)
+    watchedFiles = watchedFiles.concat(ngTwFile);
+
+    printWatchedFiles(watchedFiles)
   } else {
     console.error(`No ng-tailwind.js file found at ${ngTwFile}.
 Please run \`ng-tailwindcss configure\` in your project's root directory.
@@ -39,6 +44,5 @@ or view the Readme at https://github.com/tehpsalmist/ng-tailwindcss`)
 }
 
 function printWatchedFiles (...files) {
-  console.log(`Watching tailwind files for changes:
-  ${files.map(f => path.basename(f)).join('\n  ')}`)
+  console.log('Watching tailwind files for changes:', files);
 }


### PR DESCRIPTION
Use case:

module.exports = {
  configJS: 'tailwind.config.js',
  sourceCSS: 'src/assets/styles/tailwind.scss',
  outputCSS: 'src/tailwind-output.css',
  watch: ['src/**/*.scss'],
....
  }