### PR TITLE
use "npm ci" instead of "npm install"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install && npm test
+    - run: npm ci && npm test
       env:
         CI: true


### PR DESCRIPTION
npm clean-install (ci) is the correct way to use package-lock.json versions