### PR TITLE
feat: allow to specify sass library avoid to accidentaly used node-sass

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -6,15 +6,27 @@ const purge = require('./purge')
 // Conditionally require node-sass or dart-sass
 const pathToNodeSass = path.normalize(path.resolve(process.cwd(), 'node_modules', 'node-sass'))
 const pathToDartSass = path.normalize(path.resolve(process.cwd(), 'node_modules', 'sass'))
-let sass = null
 
-try {
-  sass = require(pathToNodeSass)
-} catch (err) {
+function defineSass (sassType) {
+  if (sassType === true) {
+    try {
+      return require(pathToNodeSass)
+    } catch {
+      try {
+        return require(pathToDartSass)
+      } catch {
+        return null
+      }
+    }
+  }
   try {
-    sass = require(pathToDartSass)
-  } catch (e) {
-    sass = null
+    if (sassType === 'node-sass') {
+      return require(pathToNodeSass)
+    } else if (sassType === 'sass' || sassType === 'dart–sass') {
+      return require(pathToDartSass)
+    }
+  } catch {
+    return null
   }
 }
 
@@ -37,6 +49,8 @@ module.exports = ({ purgeFlag, configPath }) => {
       return resolve(sourceFile)
     }
   ))
+
+  const sass = defineSass(config.sass)
 
   const sassBuild = (configPath) => new Promise((resolve, reject) => sass.render({
     file: config.sourceCSS


### PR DESCRIPTION
In case of node-sass installed as other package's dependency, node-sass is used if user only specify dart-sass as dependencies.
To avoid this case, allow to specify `sass` `node-sass` `dart-sass` to `config.sass`.
Specifying `true` is still allowed and behavior same to current implement.