### PR TITLE
fix: watch always should not purge

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -49,7 +49,7 @@ function writeConfigFile (config, file) {
   outputCSS: '${config.outputCSS.replace(/\\/g, '\\\\')}',
   // Sass
   sass: ${config.sass},
-  // PurgeCSS Settings
+  // PurgeCSS Settings in \`ngtw build\` command
   purge: ${config.purge},
   keyframes: ${config.keyframes},
   fontFace: ${config.fontFace},

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -16,7 +16,7 @@ module.exports = ({ configPath }) => {
     tailwind.on('change', (event, path) => {
       console.log('Reprocessing changes to Tailwind files')
 
-      build({ configPath })
+      build({ configPath, purgeFlag: false })
     })
 
     const hotReload = chokidar.watch([ngTwFile])
@@ -26,7 +26,7 @@ module.exports = ({ configPath }) => {
 
       console.log('Processing changes to ng-tailwind.js')
 
-      build({ configPath })
+      build({ configPath, purgeFlag: false })
     })
 
     printWatchedFiles(config.configJS, config.sourceCSS, ngTwFile)


### PR DESCRIPTION
`ngtw watch` is for development, but if `purge: true` is given in config, built css file only has selectors had written in target js/html file **at the time watch command executed**.

To resolve this, I think there is 2 way:
1. watch target js/html files and rebuild when file changes everytime.
2. not to purge in watch command.

1st way is too heavy, because `tailwind build` and purge will run per file changed.

So I think 2nd way is reasonable, and implemented.